### PR TITLE
fix: text color of copyable pre in dark mode, change button component

### DIFF
--- a/abacate-chat/src/app/components/MessageContent.tsx
+++ b/abacate-chat/src/app/components/MessageContent.tsx
@@ -3,6 +3,7 @@ import { Check, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { Button } from "./ui/button";
 
 interface MessageContentProps {
   content: string | null;
@@ -24,16 +25,16 @@ const CopyablePre = (props: any) => {
   return (
     <div style={{ position: "relative" }}>
       <pre {...props} />
-      <button
+      <Button
         onClick={handleCopy}
         aria-label={isCopied ? 'Copiado' : 'Copiar código'}
         type="button"
         role="button"
-        className="text-sm z-10 absolute top-2 right-2 rounded-sm flex items-center justify-center gap-2 px-2 py-1 hover:cursor-pointer bg-white hover:bg-gray-100"
+        className="text-sm text-gray-100 z-10 absolute top-2 right-2 rounded-sm flex items-center justify-center gap-2 px-2 py-1 hover:cursor-pointer"
       >
         {isCopied ? <Check /> : <Copy />}
         <span>{isCopied ? 'Copiado' : 'Copiar'}</span>
-      </button>
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
[EN]

I fixed copyable button in dark mode. Previously it was non legible text.

[PT]

Corrigi o texto do botão de copiar no modo escuro. Anteriormente ele não estava legível.

Exemplo/Exmaple:
<img width="1119" height="707" alt="image" src="https://github.com/user-attachments/assets/e6e7875b-aa73-44b0-b392-6b0d2eb62b17" />

Com a correção/With the fix:
<img width="1156" height="724" alt="image" src="https://github.com/user-attachments/assets/36594ec6-7056-4d3f-8222-a53cd173752f" />